### PR TITLE
fix: use memory location sendMessageToL1

### DIFF
--- a/src/CairoLib.sol
+++ b/src/CairoLib.sol
@@ -196,7 +196,7 @@ library CairoLib {
     /// @notice Performs a low-level call to send a message from the Kakarot to the Ethereum network.
     /// @param payload The payload of the message to send to the Ethereum contract. The same payload will need
     /// to be provided on L1 to consume the message.
-    function sendMessageToL1(bytes calldata payload) internal {
+    function sendMessageToL1(bytes memory payload) internal {
         (bool success,) = CAIRO_MESSAGING_ADDRESS.call(payload);
         require(success, "CairoLib: sendMessageToL1 failed");
     }


### PR DESCRIPTION
Part of https://github.com/kkrt-labs/kakarot/pull/1399